### PR TITLE
Fix typo: invalid comment delimiter in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Go Template Syntax Highlight Support for VSCode.
 
   ![HTML](./assets/screenshots/html.png)
 
-- Support syntax highlighting for Go Template embedded in unknown extension files which begin with Go Template Comment. Ex: `{{ /* Go Template */ }}`.
+- Support syntax highlighting for Go Template embedded in unknown extension files which begin with Go Template Comment. Ex: `{{- /* Go Template */ -}}`.
 
   ![Comment](./assets/screenshots/comment.png)
 


### PR DESCRIPTION
In this pull request, I revised `{{ /* Go Template */ }}` to `{{- /* Go Template */ -}}` in the README description, aligning it with the content in the screenshot "comment.png".

The original `{{ /* Go Template */ }}` is considered an invalid comment because there are spaces between `{{` and `/*` or `*/` and `}}` according to https://pkg.go.dev/text/template#hdr-Actions
```
{{/* a comment */}}
{{- /* a comment with white space trimmed from preceding and following text */ -}}
	A comment; discarded. May contain newlines.
	Comments do not nest and must start and end at the
	delimiters, as shown here.
```
It should be written as `{{- /* Go Template */ -}}` or `{{/* Go Template */}}`.
In fact, the following code panics with an error `panic: template: comments:1: unexpected "/" in command`
```go
package main

import "text/template"

func main() {
	template.Must(template.New("comments").Parse("{{ /* Go Template */ }}"))
}
``` 
